### PR TITLE
Allow NULL backend for capture/playback/duplex streams

### DIFF
--- a/miniaudio.py
+++ b/miniaudio.py
@@ -1299,8 +1299,6 @@ class CaptureDevice(AbstractDevice):
         result = lib.ma_device_init(self._context, ffi.addressof(self._devconfig), self._device)
         if result != lib.MA_SUCCESS:
             raise MiniaudioError("failed to init device", result)
-        if self._device.pContext.backend == lib.ma_backend_null:
-            raise MiniaudioError("no suitable audio backend found")
         self.backend = ffi.string(lib.ma_get_backend_name(self._device.pContext.backend)).decode()
 
     def start(self, callback_generator: CaptureCallbackGeneratorType,
@@ -1355,8 +1353,6 @@ class PlaybackDevice(AbstractDevice):
         result = lib.ma_device_init(self._context, ffi.addressof(self._devconfig), self._device)
         if result != lib.MA_SUCCESS:
             raise MiniaudioError("failed to init device", result)
-        if self._device.pContext.backend == lib.ma_backend_null:
-            raise MiniaudioError("no suitable audio backend found")
         self.backend = ffi.string(lib.ma_get_backend_name(self._device.pContext.backend)).decode()
 
     def start(self, callback_generator: PlaybackCallbackGeneratorType,
@@ -1421,8 +1417,6 @@ class DuplexStream(AbstractDevice):
         result = lib.ma_device_init(self._context, ffi.addressof(self._devconfig), self._device)
         if result != lib.MA_SUCCESS:
             raise MiniaudioError("failed to init device", result)
-        if self._device.pContext.backend == lib.ma_backend_null:
-            raise MiniaudioError("no suitable audio backend found")
         self.backend = ffi.string(lib.ma_get_backend_name(self._device.pContext.backend)).decode()
 
     def start(self, callback_generator: DuplexCallbackGeneratorType,


### PR DESCRIPTION
Hi @irmen 

I'd like to make a change to allow the NULL backend to be used. 
My use case is for running some automated tests, which don't have access to proper audio backend. 

Requesting a backend you don't have access too still raises an error (as expected)
```
python .\examples\demo1.py
Traceback (most recent call last):
  File ".\examples\demo1.py", line 14, in <module>
    device = miniaudio.PlaybackDevice(backends=[miniaudio.Backend.PULSEAUDIO])
  File "c:\users\cameron\dev\pyminiaudio2\miniaudio.py", line 1352, in __init__
    self._context = self._make_context(backends or [], thread_prio, app_name)
  File "c:\users\cameron\dev\pyminiaudio2\miniaudio.py", line 1265, in _make_context
    raise MiniaudioError("cannot init context", result)
miniaudio.MiniaudioError: ('cannot init context', -103)
```
The -103 corresponds to MA_NO_BACKEND error 
![image](https://user-images.githubusercontent.com/1007064/74919243-96fec680-53ca-11ea-9174-561293b4982b.png)



