### PR TITLE
Use cibuildwheels to build and Publish Windows/*nix wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -59,12 +59,11 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
+    name: Upload to PyPi
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
+    # upload to PyPI on every release publish
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels for ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -62,8 +62,6 @@ jobs:
     name: Upload to PyPi
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    # upload to PyPI on every release publish
-    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Build and upload to PyPI
+
+# Build on every published release
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Need to be PIP517 build in order to avoid setuptools bug - https://github.com/pypa/cibuildwheel/issues/813
+        # I dunno enough about the work involved in that - sorry!
+        # os: [ubuntu-latest, windows-latest, macos-11, macos-latest]
+          os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.10'
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+        env:
+        # I can't get windows tests to work, but at least here's linux testing the built wheels
+          CIBW_BEFORE_TEST_LINUX: mkdir -p ~/examples/samples && cp -R {project}/examples/samples/* ~/examples/samples/
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND_LINUX: "pytest {project}/tests"
+
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pypi_artifacts
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.10'
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pypi_artifacts
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: pypi_artifacts
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TEST_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def miniaudio_test_suite():
 
 if __name__ == "__main__":
     setup(
-        name="miniaudio",
+        name="shauns-cibuild-test-of-miniaudio",
         version=PKG_VERSION,
         cffi_modules=["build_ffi_module.py:ffibuilder"],
         include_dirs=[miniaudio_path],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def miniaudio_test_suite():
 
 if __name__ == "__main__":
     setup(
-        name="shauns-cibuild-test-of-miniaudio",
+        name="miniaudio",
         version=PKG_VERSION,
         cffi_modules=["build_ffi_module.py:ffibuilder"],
         include_dirs=[miniaudio_path],


### PR DESCRIPTION
This closes https://github.com/irmen/pyminiaudio/issues/36

No requirement to build piwheels - they are done by piwheels automatically on release - https://www.piwheels.org/project/miniaudio/

Currently pointing at the pypi test environment - https://test.pypi.org/project/shauns-cibuild-test-of-miniaudio/#files

It is currently configured to build windows, manylinux and musl wheels for python 3.6 up to 3.10.
It will do unit testing of the linux wheels, however I couldn't get my head around how the windows runner works to expose the audio files - hopefully someone smarter than me figures it out.

I have tested the resulting Windows wheels locally on windows x64 with python 3.9 and 3.10 - they all appear to work as expected.

If you want OS X wheels, you'll need to move to PEP517 packaging due to a cffi/packaging issue - https://github.com/pypa/cibuildwheel/issues/813

I have left the target the test pypi repo - you will also need to have the appropriate API token in your repo secrets.
If you don't want to publish the resulting wheels, you can comment out the  upload_pypi task and it will give you a zip file as an artifact with the sdist  and all the wheels.

Nice to have an alternative to portaudio bindings - great project!