### PR TITLE
Handling HTML entities in Icecast meta

### DIFF
--- a/miniaudio.py
+++ b/miniaudio.py
@@ -16,6 +16,7 @@ import array
 import urllib.request
 import inspect
 import time
+import html
 import threading
 from enum import Enum
 from typing import Generator, List, Dict, Set, Optional, Union, Any, Callable
@@ -1238,6 +1239,7 @@ class IceCastClient(StreamableSource):
     @staticmethod
     def parse_metadata(metadata: str) -> Dict[str, str]:
         meta = {}
+        metadata = html.unescape(metadata)
         for part in metadata.split(';'):
             key, _, value = part.partition('=')
             if key:

--- a/tests/test_miniaudio.py
+++ b/tests/test_miniaudio.py
@@ -306,3 +306,5 @@ def test_icecastclient_metadata_parsing():
     assert meta == {"StreamTitle": "title", "StreamUrl": "http://something.url"}
     meta = ic.parse_metadata("StreamTitle='title'with'quotes';StreamUrl='http://something.url';")
     assert meta == {"StreamTitle": "title'with'quotes", "StreamUrl": "http://something.url"}
+    meta = ic.parse_metadata("StreamTitle=TitlewithHTMLcodes&#39;and&#39;stuff;StreamUrl='http://something.url';")
+    assert meta == {"StreamTitle": "TitlewithHTMLcodes'and'stuff", "StreamUrl": "http://something.url"}


### PR DESCRIPTION
If the Icecast stream has HTML entities, then `parse_metadata()` will split after the character, since HTML entities terminate in a ';'.

Resolving this by unescaping all the HTML entities before splitting the meta into key-value pairs.

Also added test case for handing HTML entities in the presence of multiple tags.