### PR TITLE
Update cibuildwheel version to fix builds in windows, add python3.12 to wheel tests. 

### DIFF
--- a/.github/workflows/wheelbuilder.yml
+++ b/.github/workflows/wheelbuilder.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.10'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.13.0
+        uses: pypa/cibuildwheel@v2.16.0
         env:
         # I can't get windows tests to work, but at least here's linux testing the built wheels
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/wheelbuilder.yml
+++ b/.github/workflows/wheelbuilder.yml
@@ -33,7 +33,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest
           CIBW_ARCHS_MACOS: 'x86_64 arm64'
           # CIBW_BUILD: 'cp39-* cp310-* cp311-*'
-          CIBW_SKIP: 'cp36-*'
+          CIBW_SKIP: 'cp36-* cp37-*'
           CIBW_TEST_COMMAND_LINUX: "cd {project} && pytest -v tests/"
 
 

--- a/.github/workflows/wheeltest.yml
+++ b/.github/workflows/wheeltest.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.10'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.13.0
+        uses: pypa/cibuildwheel@v2.16
         env:
         # I can't get windows tests to work, but at least here's linux testing the built wheels
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/wheeltest.yml
+++ b/.github/workflows/wheeltest.yml
@@ -28,7 +28,7 @@ jobs:
         # I can't get windows tests to work, but at least here's linux testing the built wheels
           CIBW_TEST_REQUIRES: pytest
           CIBW_ARCHS_MACOS: 'x86_64 arm64'
-          CIBW_BUILD: 'cp39-* cp310-* cp311-*'
+          CIBW_BUILD: 'cp39-* cp310-* cp311-* cp312-*'
           CIBW_TEST_COMMAND_LINUX: "cd {project} && pytest -v tests/"
 
 


### PR DESCRIPTION
When published this would add support for python 3.12 which is the now stable version