### PR TITLE
Add bindings for `ma_device_{get|set}_master_volume` and add methods to `AbstractDevice`

### DIFF
--- a/build_ffi_module.py
+++ b/build_ffi_module.py
@@ -606,6 +606,8 @@ typedef ma_bool32 (* ma_enum_devices_callback_proc)(ma_context* pContext, ma_dev
     ma_result ma_device_start(ma_device* pDevice);
     ma_result ma_device_stop(ma_device* pDevice);
     ma_bool32 ma_device_is_started(ma_device* pDevice);
+    ma_result ma_device_set_master_volume(ma_device* pDevice, float volume);
+    ma_result ma_device_get_master_volume(ma_device* pDevice, float* pVolume);
     ma_context_config ma_context_config_init(void);
     ma_device_config ma_device_config_init(ma_device_type deviceType);
     ma_decoder_config ma_decoder_config_init(ma_format outputFormat, ma_uint32 outputChannels, ma_uint32 outputSampleRate);

--- a/miniaudio.py
+++ b/miniaudio.py
@@ -1872,6 +1872,7 @@ class AbstractDevice:
         self.stop_callback = None
 
     def set_master_volume(self, volume: float) -> None:
+        """Set the master volume of the device. Volume should be between 0.0 and 1.0."""
         if volume < 0.0 or volume > 1.0:
             raise MiniaudioError("volume must be between 0.0 and 1.0", volume)
 
@@ -1884,6 +1885,7 @@ class AbstractDevice:
             raise MiniaudioError("failed to set master volume", result)
     
     def get_master_volume(self) -> float:
+        """Get the master volume of the device. Returns a value between 0.0 and 1.0."""
         if self._device is None:
             raise MiniaudioError("device is closed")
 

--- a/miniaudio.py
+++ b/miniaudio.py
@@ -1871,6 +1871,28 @@ class AbstractDevice:
             self._device = None
         self.stop_callback = None
 
+    def set_master_volume(self, volume: float) -> None:
+        if volume < 0.0 or volume > 1.0:
+            raise MiniaudioError("volume must be between 0.0 and 1.0", volume)
+
+        if self._device is None:
+            raise MiniaudioError("device is closed")
+
+        result = lib.ma_device_set_master_volume(self._device, volume)
+
+        if result != lib.MA_SUCCESS:
+            raise MiniaudioError("failed to set master volume", result)
+    
+    def get_master_volume(self) -> float:
+        if self._device is None:
+            raise MiniaudioError("device is closed")
+
+        with ffi.new("float *") as volume:
+            result = lib.ma_device_get_master_volume(self._device, volume)
+            if result != lib.MA_SUCCESS:
+                raise MiniaudioError("failed to get master volume", result)
+            return volume[0]
+    
     def _stop_callback(self, device: ffi.CData) -> None:
         """Called when the device is stopped (i.e. device disconnect or manual stop) Doesn't work consistently however."""
         if self.stop_callback:


### PR DESCRIPTION
This pull requests adds bindings for

* `ma_device_get_master_volume`
* `ma_device_set_master_volume`

and adds methods to `miniaudio.AbstractDevice` to control the master volume of the device.